### PR TITLE
Add helm hooks for admission controller deplolyment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,14 +27,14 @@ jobs:
           cache-dependency-path: go.sum
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
-      # - name: Run GoReleaser
-      #   uses: goreleaser/goreleaser-action@v6
-      #   with:
-      #     distribution: goreleaser
-      #     version: latest
-      #     args: release --clean --timeout 90m
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --timeout 90m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,16 +27,14 @@ jobs:
           cache-dependency-path: go.sum
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0
-      - name: Set repository name
-        run: echo "REPO_NAME=${{ github.repository_owner }}/kubedns-shepherd" >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean --timeout 90m
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Run GoReleaser
+      #   uses: goreleaser/goreleaser-action@v6
+      #   with:
+      #     distribution: goreleaser
+      #     version: latest
+      #     args: release --clean --timeout 90m
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,21 +20,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean --timeout 90m
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Set up Go
+      #   uses: actions/setup-go@v5
+      #   with:
+      #     go-version-file: go.mod
+      #     cache-dependency-path: go.sum
+      # - name: Install Syft
+      #   uses: anchore/sbom-action/download-syft@v0
+      # - name: Run GoReleaser
+      #   uses: goreleaser/goreleaser-action@v6
+      #   with:
+      #     distribution: goreleaser
+      #     version: latest
+      #     args: release --clean --timeout 90m
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@master
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ kos:
   - build: kubedns-shepherd
     main: ./cmd/...
     base_image: ghcr.io/distroless/static:latest
-    repository: ghcr.io/mlladb/kubedns-shepherd
+    repository: ghcr.io/eminaktas/kubedns-shepherd
     tags:
       - '{{ .Tag }}'
       - '{{ if not .Prerelease }}latest{{ end }}'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.1
+VERSION ?= 0.2.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.0
+VERSION ?= 0.2.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/chart/kubedns-shepherd/Chart.yaml
+++ b/chart/kubedns-shepherd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedns-shepherd
 description: A Kubernetes controller that manages the DNS configuration of workloads, ensuring efficient and reliable way to configure DNS within your Kubernetes cluster.
 type: application
-version: 0.2.1
-appVersion: "v0.2.1"
+version: 0.2.2
+appVersion: "v0.2.2"
 
 dependencies:
   - name: cert-manager

--- a/chart/kubedns-shepherd/Chart.yaml
+++ b/chart/kubedns-shepherd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedns-shepherd
 description: A Kubernetes controller that manages the DNS configuration of workloads, ensuring efficient and reliable way to configure DNS within your Kubernetes cluster.
 type: application
-version: 0.2.0
-appVersion: "v0.2.0"
+version: 0.2.1
+appVersion: "v0.2.1"
 
 dependencies:
   - name: cert-manager

--- a/chart/kubedns-shepherd/templates/deployment.yaml
+++ b/chart/kubedns-shepherd/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- with .Values.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: ghcr.io/mlladb/kubedns-shepherd:v0.0.12 #{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
I've tested the following fix for the further issue described in [Issue 25](https://github.com/eminaktas/kubedns-shepherd/issues/25) at it works as expected. I don't think there are any likely issues to appear due to this change. 